### PR TITLE
When error block is executed, do not execute the response block as well

### DIFF
--- a/SCNetworkRequest/SCNetworkRequest.m
+++ b/SCNetworkRequest/SCNetworkRequest.m
@@ -349,6 +349,7 @@ static int sNumNetworkRequests;
         
         if(parseError && weakSelf.error) {
             weakSelf.error(nil, 0, parseError, nil);
+            return;
         }
         
         // strip NSNull objects out of response, if requested


### PR DESCRIPTION
Is this intentional? Had a case where the response data wasn't deserializing properly (APIs returning HTML error page) and ended up executing both blocks following a single request call.
